### PR TITLE
Fix Vercel build error by removing runtime specification

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,9 +8,7 @@
   "cleanUrls": true,
   "trailingSlash": false,
   "functions": {
-    "api/index.ts": {
-      "runtime": "nodejs20.x"
-    }
+    "api/index.ts": {}
   },
   "rewrites": [
     {


### PR DESCRIPTION
## Purpose
Fix Vercel deployment build error caused by invalid function runtime specification. The user was encountering a build failure with the error "Function Runtimes must have a valid version, for example `now-php@1.0.0`" when deploying to Vercel.

## Code changes
- Removed explicit `runtime: "nodejs20.x"` specification from `api/index.ts` function configuration in `vercel.json`
- Simplified function configuration to use Vercel's default runtime detection
- This allows Vercel to automatically determine the appropriate Node.js runtime version

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f16bbd432c5648628766a23a628732db/pixel-nest)

👀 [Preview Link](https://f16bbd432c5648628766a23a628732db-pixel-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f16bbd432c5648628766a23a628732db</projectId>-->
<!--<branchName>pixel-nest</branchName>-->