### PR TITLE
Fix Vercel function config by adding nodejs20.x runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,9 @@
   "cleanUrls": true,
   "trailingSlash": false,
   "functions": {
-    "api/index.ts": {}
+    "api/index.ts": {
+      "runtime": "nodejs20.x"
+    }
   },
   "rewrites": [
     {


### PR DESCRIPTION
## Purpose
Fix Vercel deployment error where the build was failing with "Function must contain at least one property" error. The user was experiencing deployment issues in their HellBoost project due to an incomplete function configuration in vercel.json.

## Code changes
- Added `runtime: "nodejs20.x"` property to the `api/index.ts` function configuration in `vercel.json`
- This ensures the function has the required properties for successful Vercel deployment

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f16bbd432c5648628766a23a628732db/stellar-world)

👀 [Preview Link](https://f16bbd432c5648628766a23a628732db-stellar-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f16bbd432c5648628766a23a628732db</projectId>-->
<!--<branchName>stellar-world</branchName>-->