### PR TITLE
Remove explicit runtime from api/index.ts function

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,9 +8,7 @@
   "cleanUrls": true,
   "trailingSlash": false,
   "functions": {
-    "api/index.ts": {
-      "runtime": "nodejs18.x"
-    }
+    "api/index.ts": {}
   },
   "rewrites": [
     {


### PR DESCRIPTION
## Purpose
Based on the conversation, the user identified that function runtimes must have a valid version format (e.g., `now-php@1.0.0`). This change addresses potential runtime configuration issues by removing the explicit runtime specification.

## Code changes
- Removed the explicit `"runtime": "nodejs20.x"` configuration from the `api/index.ts` function in `vercel.json`
- The function configuration now uses an empty object `{}`, allowing Vercel to use default runtime detection

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f16bbd432c5648628766a23a628732db/mystic-nest)

👀 [Preview Link](https://f16bbd432c5648628766a23a628732db-mystic-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f16bbd432c5648628766a23a628732db</projectId>-->
<!--<branchName>mystic-nest</branchName>-->